### PR TITLE
feat(ui): use Typesense color as primary color

### DIFF
--- a/packages/docsearch-css/src/_variables.css
+++ b/packages/docsearch-css/src/_variables.css
@@ -1,7 +1,7 @@
 /* Variables */
 
 :root {
-  --docsearch-primary-color: rgb(84, 104, 255);
+  --docsearch-primary-color: rgb(16, 53, 188);
   --docsearch-text-color: rgb(28, 30, 33);
   --docsearch-spacing: 12px;
   --docsearch-icon-stroke-width: 1.4;


### PR DESCRIPTION
## Change Summary

Use Typesense primary color by setting `--docsearch-primary-color`.

Closes #5

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
