### PR TITLE
Add plugin for Matomo to track site search keywords

### DIFF
--- a/packages/docsearch-react/src/DocSearch.tsx
+++ b/packages/docsearch-react/src/DocSearch.tsx
@@ -43,6 +43,7 @@ export interface DocSearchProps {
   navigator?: AutocompleteOptions<InternalDocSearchHit>['navigator'];
   translations?: DocSearchTranslations;
   getMissingResultsUrl?: ({ query }: { query: string }) => string;
+  matomoSearchAnalytics?: boolean;
 }
 
 export function DocSearch(props: DocSearchProps) {

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -52,6 +52,7 @@ export function DocSearchModal({
   initialQuery: initialQueryFromProp = '',
   translations = {},
   getMissingResultsUrl,
+  matomoSearchAnalytics = false,
 }: DocSearchModalProps) {
   const {
     footer: footerTranslations,
@@ -127,7 +128,12 @@ export function DocSearchModal({
     [favoriteSearches, recentSearches, disableUserPersonalization]
   );
 
-  const matomoPlugin = createMatomoPlugin();
+  var plugins_to_load: any = [];
+
+  if (matomoSearchAnalytics) {
+    const matomoPlugin = createMatomoPlugin();
+    plugins_to_load.push(matomoPlugin);
+  };
 
   const autocomplete = React.useMemo(
     () =>
@@ -286,7 +292,7 @@ export function DocSearchModal({
               );
             });
         },
-        plugins: [matomoPlugin],
+        plugins: plugins_to_load,
       }),
     [
       typesenseCollectionName,

--- a/packages/docsearch-react/src/DocSearchModal.tsx
+++ b/packages/docsearch-react/src/DocSearchModal.tsx
@@ -2,6 +2,8 @@ import type { AutocompleteState } from '@algolia/autocomplete-core';
 import { createAutocomplete } from '@algolia/autocomplete-core';
 import React from 'react';
 
+import { createMatomoPlugin } from './MatomoPlugin';
+
 import { MAX_QUERY_SIZE } from './constants';
 import type { DocSearchProps } from './DocSearch';
 import type { FooterTranslations } from './Footer';
@@ -124,6 +126,8 @@ export function DocSearchModal({
     },
     [favoriteSearches, recentSearches, disableUserPersonalization]
   );
+
+  const matomoPlugin = createMatomoPlugin();
 
   const autocomplete = React.useMemo(
     () =>
@@ -282,6 +286,7 @@ export function DocSearchModal({
               );
             });
         },
+        plugins: [matomoPlugin],
       }),
     [
       typesenseCollectionName,

--- a/packages/docsearch-react/src/MatomoPlugin.tsx
+++ b/packages/docsearch-react/src/MatomoPlugin.tsx
@@ -19,7 +19,7 @@ var matomoSiteSearch_debounced = debounce(_matomoSiteSearch, 500);
 export function createMatomoPlugin() {
     return {
         onStateChange({ state }) {
-            if ( state.isOpen && state.query.length > 0 && query_cache !== state.query ) {
+            if ( state.isOpen && state.query.length > 2 && query_cache !== state.query ) {
                 matomoSiteSearch_debounced(state.query, state.context.nbHits);
             }
         },

--- a/packages/docsearch-react/src/MatomoPlugin.tsx
+++ b/packages/docsearch-react/src/MatomoPlugin.tsx
@@ -6,19 +6,22 @@ declare global {
     }
 }
 
+var query_cache = "";
+
 function _matomoSiteSearch(query: string, hits: string) {
+        query_cache = query;
         var _paq = window._paq = window._paq || [];
-        if (query.length > 0) {
-            _paq.push(['trackSiteSearch', query, false, hits]);
-        }
+        _paq.push(['trackSiteSearch', query, false, hits]);
 }
 
-var matomoSiteSearch_debounced = debounce(_matomoSiteSearch, 400);
+var matomoSiteSearch_debounced = debounce(_matomoSiteSearch, 500);
 
 export function createMatomoPlugin() {
     return {
         onStateChange({ state }) {
-            matomoSiteSearch_debounced(state.query, state.context.nbHits);
-        }
+            if ( state.isOpen && state.query.length > 0 && query_cache !== state.query ) {
+                matomoSiteSearch_debounced(state.query, state.context.nbHits);
+            }
+        },
     };
 };

--- a/packages/docsearch-react/src/MatomoPlugin.tsx
+++ b/packages/docsearch-react/src/MatomoPlugin.tsx
@@ -1,0 +1,24 @@
+import debounce from 'lodash/debounce';
+
+declare global {
+    interface Window {
+        _paq: any;
+    }
+}
+
+function _matomoSiteSearch(query: string, hits: string) {
+        var _paq = window._paq = window._paq || [];
+        if (query.length > 0) {
+            _paq.push(['trackSiteSearch', query, false, hits]);
+        }
+}
+
+var matomoSiteSearch_debounced = debounce(_matomoSiteSearch, 400);
+
+export function createMatomoPlugin() {
+    return {
+        onStateChange({ state }) {
+            matomoSiteSearch_debounced(state.query, state.context.nbHits);
+        }
+    };
+};


### PR DESCRIPTION
## Change Summary

Use the plugins API for autocomplete, hook into the state change, retrieve the query term from the use, and send the query term together with the search results from the global context to Matomo.

* autocomplete plugins: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/plugins/
* autocomplete state: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/state/
* autocomplete access data with context: https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/context/

https://developer.matomo.org/guides/tracking-javascript-guide#internal-search-tracking

Relates to https://github.com/typesense/typesense-docsearch.js/issues/16

The implementation requires that the Matomo tracking code is already part of the web page that calls the docsearch modal. It just references it and adds the call for the Matomo site search.

To use the plugin, you need to add `matomoSearchAnalytics: true` to the properties for the `docsearch()` function.

## PR Checklist

- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
